### PR TITLE
Upgrade to SonarQube 7.9

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
+*.md text eol=lf
+**/root/**/* text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Emiliano Sune (emiliano.sune@gmail.com)
 # Define Plug-in Versions
 ARG SONAR_ZAP_PLUGIN_VERSION=1.2.0
 
-ENV SONAR_VERSION=7.9 \
+ENV SONAR_VERSION=7.9.1 \
   SONARQUBE_HOME=/opt/sonarqube \
   SONARQUBE_JDBC_USERNAME=sonar \
   SONARQUBE_JDBC_PASSWORD=sonar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV SONAR_VERSION=7.9.1 \
   SONARQUBE_JDBC_PASSWORD=sonar \
   SONARQUBE_JDBC_URL=
 
-ENV SONARQUBE_PLUGIN_DIR=$SONARQUBE_HOME/lib/bundled-plugins
+ENV SONARQUBE_PLUGIN_DIR=$SONARQUBE_HOME/extensions/plugins
 
 ENV SUMMARY="SonarQube for bcgov OpenShift" \
   DESCRIPTION="This image creates the SonarQube image for use at bcgov/OpenShift"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,44 @@
-FROM jboss/base-jdk:8
+FROM jboss/base-jdk:11
 
 MAINTAINER Erik Jacobs <erikmjacobs@gmail.com>
 MAINTAINER Siamak Sadeghianfar <siamaksade@gmail.com>
 MAINTAINER Roland Stens (roland.stens@gmail.com)
 MAINTAINER Wade Barnes (wade.barnes@shaw.ca)
+MAINTAINER Emiliano Sune (emiliano.sune@gmail.com)
 
 # Define Plug-in Versions
-ARG SONAR_ZAP_PLUGIN_VERSION=1.1.2
-ARG QUALINSIGHT_SONARQUBE_BADGES_VERSION=3.0.1
+ARG SONAR_ZAP_PLUGIN_VERSION=1.2.0
 
-ENV SONAR_VERSION=6.7.5 \
-    SONARQUBE_HOME=/opt/sonarqube \
-    SONARQUBE_JDBC_USERNAME=sonar \
-    SONARQUBE_JDBC_PASSWORD=sonar \
-    SONARQUBE_JDBC_URL=
+ENV SONAR_VERSION=7.9 \
+  SONARQUBE_HOME=/opt/sonarqube \
+  SONARQUBE_JDBC_USERNAME=sonar \
+  SONARQUBE_JDBC_PASSWORD=sonar \
+  SONARQUBE_JDBC_URL=
 
 ENV SONARQUBE_PLUGIN_DIR=$SONARQUBE_HOME/lib/bundled-plugins
 
 ENV SUMMARY="SonarQube for bcgov OpenShift" \
-    DESCRIPTION="This image creates the SonarQube image for use at bcgov/OpenShift"
+  DESCRIPTION="This image creates the SonarQube image for use at bcgov/OpenShift"
 
 LABEL summary="$SUMMARY" \
-      description="$DESCRIPTION" \
-      io.k8s.description="$DESCRIPTION" \
-      io.k8s.display-name="sonarqube" \
-      io.openshift.expose-services="9000:http" \
-      io.openshift.tags="sonarqube" \
-      release="$SONAR_VERSION"
+  description="$DESCRIPTION" \
+  io.k8s.description="$DESCRIPTION" \
+  io.k8s.display-name="sonarqube" \
+  io.openshift.expose-services="9000:http" \
+  io.openshift.tags="sonarqube" \
+  release="$SONAR_VERSION"
 
 USER root
 EXPOSE 9000
 ADD root /
 
 RUN set -x \
-    && cd /opt \
-    && curl -o sonarqube.zip -fSL https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip \
-    && unzip sonarqube.zip \
-    && mv sonarqube-$SONAR_VERSION sonarqube \
-    && rm sonarqube.zip* \
-    && rm -rf $SONARQUBE_HOME/bin/*
+  && cd /opt \
+  && curl -o sonarqube.zip -fSL https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-$SONAR_VERSION.zip \
+  && unzip sonarqube.zip \
+  && mv sonarqube-$SONAR_VERSION sonarqube \
+  && rm sonarqube.zip* \
+  && rm -rf $SONARQUBE_HOME/bin/*
 
 # ================================================================================================================================================================================
 # Bundle Plug-in(s)
@@ -46,24 +46,14 @@ RUN set -x \
 
 # sonar-zap-plugin
 # https://github.com/Coveros/zap-sonar-plugin
-# Version 1.1.2 of the plug-in requires LTS version 6.7.5 of SonarQube, and is not compatible with version 7.x yet.
-# - https://github.com/Coveros/zap-sonar-plugin/issues/40
-# - https://github.com/Coveros/zap-sonar-plugin/pull/41
 ADD https://github.com/Coveros/zap-sonar-plugin/releases/download/sonar-zap-plugin-$SONAR_ZAP_PLUGIN_VERSION/sonar-zap-plugin-$SONAR_ZAP_PLUGIN_VERSION.jar $SONARQUBE_PLUGIN_DIR
-
-# qualinsight-plugins-sonarqube-badges
-# https://github.com/QualInsight/qualinsight-plugins-sonarqube-badges
-# This plug-in is for use with SonarQube versions <7.1.
-# From SonarQube 7.1 badges are available from the platform without a plugin.
-ADD https://github.com/QualInsight/qualinsight-plugins-sonarqube-badges/releases/download/qualinsight-plugins-sonarqube-badges-$QUALINSIGHT_SONARQUBE_BADGES_VERSION/qualinsight-sonarqube-badges-$QUALINSIGHT_SONARQUBE_BADGES_VERSION.jar $SONARQUBE_PLUGIN_DIR
-# ================================================================================================================================================================================
 
 WORKDIR $SONARQUBE_HOME
 COPY run.sh $SONARQUBE_HOME/bin/
 
 RUN useradd -r sonar
 RUN /usr/bin/fix-permissions $SONARQUBE_HOME \
-    && chmod 775 $SONARQUBE_HOME/bin/run.sh
+  && chmod 775 $SONARQUBE_HOME/bin/run.sh
 
 USER sonar
 ENTRYPOINT ["./bin/run.sh"]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ An example Jenkins file [SonarQube-StaticScan-Jenkinsfile](./jenkins/SonarQube-S
 ## Congratulations - You have integrated static code scanning into your project
 You can now browse your project report on the SonarQube server site.  To find the link, browse to the overview of your `tools` project using the OpenShift console and click on the URL for the **SonarQube Application**.
 
-## Next Steps:
+## Next Steps
 
 ### Code Coverage Results
 Now that you have static scanning, you'll probably notice your code coverage results are at 0% since no unit tests are being executed during the scan.  You'll likely what to integrate unit tests into the scans so you get code coverage metrics to help you determine how well you are testing your code.  **As you journey down this road, please contribute your experience back to this project to make it better for the whole community.**
@@ -144,6 +144,7 @@ For SonarQube versions <7.1 you will need to use the [SVG Badges](https://github
 
 - [Troubleshooting Jenkins Slave Startup Issues](./docs/troubleshooting-jenkins-slave-startup-issues.md)
 - [Upgrading with Bundled Plugins](./docs/upgrading-with-bundled-plugins.md)
+- [Upgrading Plugins Manually](./docs/upgrading-plugins-manually.md)
 - [Upgrading between LTS versions](https://docs.sonarqube.org/latest/setup/upgrading/)
 
 # Getting Help or Reporting an Issue

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For SonarQube versions <7.1 you will need to use the [SVG Badges](https://github
 - [Troubleshooting Jenkins Slave Startup Issues](./docs/troubleshooting-jenkins-slave-startup-issues.md)
 - [Upgrading with Bundled Plugins](./docs/upgrading-with-bundled-plugins.md)
 - [Upgrading Plugins Manually](./docs/upgrading-plugins-manually.md)
-- [Upgrading between LTS versions](https://docs.sonarqube.org/latest/setup/upgrading/)
+- [Upgrading between LTS versions](./docs/upgrading-between-lts-versions.md)
 
 # Getting Help or Reporting an Issue
 To report bugs/issues/feature requests, please file an [issue](../../issues).

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ For SonarQube versions <7.1 you will need to use the [SVG Badges](https://github
 
 [TheOrgBook](https://github.com/bcgov/TheOrgBook) provides an example of the concepts outlined here, and demonstrates the use of static code scanning, ZAP report integration, and quality badges.
 
+# Upgrading Between LTS Versions
+
+When upgrading between LTS versions of SonarQube (as an example, going from 6.7.x to 7.9.x) it will be necessary to first upgrade to all the intermediary LTS versions.
+Even doing so, it is possible that the upgrade will cause the existing reports to be lost, therefore forcing the scan history to start over from a clean state.
+
+For more information on this topic, please refer to the [upgrading SonarQube docs](https://docs.sonarqube.org/latest/setup/upgrading/).
+
+
 # References
 - [SonarQube](https://www.sonarqube.org/)
 
@@ -145,7 +153,6 @@ For SonarQube versions <7.1 you will need to use the [SVG Badges](https://github
 - [Troubleshooting Jenkins Slave Startup Issues](./docs/troubleshooting-jenkins-slave-startup-issues.md)
 - [Upgrading with Bundled Plugins](./docs/upgrading-with-bundled-plugins.md)
 - [Upgrading Plugins Manually](./docs/upgrading-plugins-manually.md)
-- [Upgrading between LTS versions](./docs/upgrading-between-lts-versions.md)
 
 # Getting Help or Reporting an Issue
 To report bugs/issues/feature requests, please file an [issue](../../issues).

--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ SonarQube server images are now available on DockerHub:
 - [bcgovimages/sonarqube](https://hub.docker.com/r/bcgovimages/sonarqube/)
 
 ## Building the SonarQube Server Image
-The SonarQube server image (`bcgovimages/sonarqube:6.7.5`) is already available on DockerHub, so **you do not have to repeat this step** unless you are building a customized or updated version of the SonarQube Server.
+The SonarQube server image (`bcgovimages/sonarqube:7.9.1`) is already available on DockerHub, so **you do not have to repeat this step** unless you are building a customized or updated version of the SonarQube Server.
 
 Logon to your `tools` project and run the following command:
 
-    oc new-build https://github.com/BCDevOps/sonarqube --name=sonarqube --to=sonarqube:6.7.5
+    oc new-build https://github.com/BCDevOps/sonarqube --name=sonarqube --to=sonarqube:7.9.1
 
 ## Deploy on OpenShift
 The [sonarqube-postgresql-template](./sonarqube-postgresql-template.yaml) has been provided to allow you to quickly and easily deploy a fully functional instance of the SonarQube server, complete with persistent storage, into your `tools` project.  The template will create all of the necessary resources for you.
 
 Logon to your `tools` project and run the following command:
 
-    oc new-app -f sonarqube-postgresql-template.yaml --param=SONARQUBE_VERSION=6.7.5
+    oc new-app -f sonarqube-postgresql-template.yaml --param=SONARQUBE_VERSION=7.9.1
  
 ## Change the Default Admin Password
 When the SonarQube server is first deployed it is using a default `admin` password.  For security, it is **highly** recommended you change it.  The [UpdateSqAdminPw](./provisioning/updatesqadminpw.sh) script has been provided to make this easy.  The script will generate a random password, store it in an OpenShift secret named `sonarqube-admin-password`, and update the admin password of the SonarQube server instance.
@@ -104,7 +104,7 @@ You can now browse your project report on the SonarQube server site.  To find th
 Now that you have static scanning, you'll probably notice your code coverage results are at 0% since no unit tests are being executed during the scan.  You'll likely what to integrate unit tests into the scans so you get code coverage metrics to help you determine how well you are testing your code.  **As you journey down this road, please contribute your experience back to this project to make it better for the whole community.**
 
 ### Integrate OWASP ZAP Security Vulnerability Scanning into SonarQube
-To make the results of your ZAP security vulnerability scanning accessible and therefore more actionable, you can integrate the scan results into a SonarQube project report.  To accomplish this you can use the [ZAP Plugin for SonarQube](https://github.com/Coveros/zap-sonar-plugin), which is bundled in the `bcgovimages/sonarqube:6.7.5` image.
+To make the results of your ZAP security vulnerability scanning accessible and therefore more actionable, you can integrate the scan results into a SonarQube project report.  To accomplish this you can use the [ZAP Plugin for SonarQube](https://github.com/Coveros/zap-sonar-plugin), which is bundled in the `bcgovimages/sonarqube:7.9.1` image.
 
 The [SonarQube-Integrated-ZapScan-Jenkinsfile](./jenkins/SonarQube-Integrated-ZapScan-Jenkinsfile) example shows you how to utilize ZAP and the plug-in together to perform a ZAP security vulnerability scan on your application, and then publish the report with SonarQube.
 
@@ -144,6 +144,7 @@ For SonarQube versions <7.1 you will need to use the [SVG Badges](https://github
 
 - [Troubleshooting Jenkins Slave Startup Issues](./docs/troubleshooting-jenkins-slave-startup-issues.md)
 - [Upgrading with Bundled Plugins](./docs/upgrading-with-bundled-plugins.md)
+- [Upgrading between LTS versions](https://docs.sonarqube.org/latest/setup/upgrading/)
 
 # Getting Help or Reporting an Issue
 To report bugs/issues/feature requests, please file an [issue](../../issues).

--- a/docs/upgrading-between-lts-versions.md
+++ b/docs/upgrading-between-lts-versions.md
@@ -1,6 +1,0 @@
-# Upgrading Between LTS Versions
-
-When upgrading between LTS versions of SonarQube (as an example, going from 6.7.x to 7.9.x) it will be necessary to first upgrade to all the intermediary LTS versions.
-Even doing so, it is possible that the upgrade will cause the existing reports to be lost, therefore forcing the scan history to start over from a clean state.
-
-For more information on this topic, please refer to the [upgrading SonarQube docs](https://docs.sonarqube.org/latest/setup/upgrading/).

--- a/docs/upgrading-between-lts-versions.md
+++ b/docs/upgrading-between-lts-versions.md
@@ -1,0 +1,6 @@
+# Upgrading Between LTS Versions
+
+When upgrading between LTS versions of SonarQube (as an example, going from 6.7.x to 7.9.x) it will be necessary to first upgrade to all the intermediary LTS versions.
+Even doing so, it is possible that the upgrade will cause the existing reports to be lost, therefore forcing the scan history to start over from a clean state.
+
+For more information on this topic, please refer to the [upgrading SonarQube docs](https://docs.sonarqube.org/latest/setup/upgrading/).

--- a/docs/upgrading-plugins-manually.md
+++ b/docs/upgrading-plugins-manually.md
@@ -1,0 +1,11 @@
+# Upgrading Plugins Manually
+
+If it becomes necessary to manually install a plugin tha is not bundled with the SonarQube image, or an updated version of an existing pluging is required,
+after downloading the plugin's JAR file execute the following command to copy it to the pod's plugin directory:
+
+```oc cp ./my-sonar-plugin.jar my-openshift-namespace/sonarqube-pod-name:/opt/sonarqube/extensions/plugins```
+
+A restart of the pod will be required after copying a new/updated plugin.
+
+# References
+- [SonarQube: Installing Plugin](https://docs.sonarqube.org/latest/setup/install-plugin/)

--- a/docs/upgrading-plugins-manually.md
+++ b/docs/upgrading-plugins-manually.md
@@ -1,6 +1,6 @@
 # Upgrading Plugins Manually
 
-If it becomes necessary to manually install a plugin tha is not bundled with the SonarQube image, or an updated version of an existing pluging is required,
+If it becomes necessary to manually install a plugin that is not bundled with the SonarQube image, or an updated version of an existing pluging is required,
 after downloading the plugin's JAR file execute the following command to copy it to the pod's plugin directory:
 
 ```oc cp ./my-sonar-plugin.jar my-openshift-namespace/sonarqube-pod-name:/opt/sonarqube/extensions/plugins```

--- a/sonarqube-postgresql-template.yaml
+++ b/sonarqube-postgresql-template.yaml
@@ -316,7 +316,7 @@ parameters:
   - displayName: SonarQube version
     name: SONARQUBE_VERSION
     required: true
-    value: '6.7.5'
+    value: '7.9.1'
   - description: Password for SonarQube Server PostgreSQL backend
     displayName: SonarQube's PostgreSQL Password
     from: '[a-zA-Z0-9]{16}'


### PR DESCRIPTION
Updates for the image version 7.9 of SonarQube. The Docker container was tested by performing a scan, and it appears to have worked correctly.

Based on the [SonarQube upgrade guide](https://docs.sonarqube.org/latest/setup/upgrading/) though, we will probably want/need to upgrade every instance in OpenShift to _v6.7.7_ **BEFORE** we can upgrade to v7.9.

Some backup and maintenance steps on the PostgreSQL instance backing the scan database may be necessary as well, as decribed in the document.

Badges and Zap scan integration have not yet been tested.