### PR TITLE
Use netapps as storage class instead of gluster

### DIFF
--- a/sonarqube-postgresql-template.yaml
+++ b/sonarqube-postgresql-template.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Template
-message: 'Login to SonarQube with the default admin user: admin/admin'
+message: "Login to SonarQube with the default admin user: admin/admin"
 metadata:
   annotations:
     description: The SonarQube OpenShift template
-    tags: 'instant-app,sonarqube'
+    tags: "instant-app,sonarqube"
   name: sonarqube
 objects:
   - apiVersion: v1
@@ -45,14 +45,14 @@ objects:
       username: YWRtaW4=
     kind: Secret
     labels:
-        app: sonarqube
+      app: sonarqube
     metadata:
       annotations:
-        template.openshift.io/base64-expose-password: '{.data[''password'']}'
+        template.openshift.io/base64-expose-password: "{.data['password']}"
       name: sonarqube-admin-password
     stringData:
       password: ${SONARQUBE_ADMIN_PASSWORD}
-    type: kubernetes.io/basic-auth    
+    type: kubernetes.io/basic-auth
   - apiVersion: v1
     kind: ImageStream
     metadata:
@@ -66,9 +66,9 @@ objects:
             tags: sonarqube
           from:
             kind: DockerImage
-            name: 'bcgovimages/sonarqube:${SONARQUBE_VERSION}'
+            name: "bcgovimages/sonarqube:${SONARQUBE_VERSION}"
           importPolicy: {}
-          name: '${SONARQUBE_VERSION}'
+          name: "${SONARQUBE_VERSION}"
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:
@@ -102,9 +102,9 @@ objects:
           containers:
             - env:
                 - name: SONARQUBE_JDBC_PASSWORD
-                  value: '${POSTGRESQL_PASSWORD}'
+                  value: "${POSTGRESQL_PASSWORD}"
                 - name: SONARQUBE_JDBC_URL
-                  value: 'jdbc:postgresql://postgresql-sonarqube/sonar'
+                  value: "jdbc:postgresql://postgresql-sonarqube/sonar"
                 - name: SONARQUBE_JDBC_USERNAME
                   value: sonar
               volumeMounts:
@@ -119,8 +119,8 @@ objects:
                   subPath: temp
                 - mountPath: /opt/sonarqube/extensions/plugins
                   name: sonar-plugins
-                  subPath: plugins      
-              image: ' '
+                  subPath: plugins
+              image: " "
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -174,7 +174,7 @@ objects:
               - sonarqube
             from:
               kind: ImageStreamTag
-              name: 'sonarqube:${SONARQUBE_VERSION}'
+              name: "sonarqube:${SONARQUBE_VERSION}"
           type: ImageChange
   - apiVersion: v1
     kind: Service
@@ -221,10 +221,10 @@ objects:
                 - name: POSTGRESQL_USER
                   value: sonar
                 - name: POSTGRESQL_PASSWORD
-                  value: '${POSTGRESQL_PASSWORD}'
+                  value: "${POSTGRESQL_PASSWORD}"
                 - name: POSTGRESQL_DATABASE
                   value: sonar
-              image: ' '
+              image: " "
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -242,8 +242,8 @@ objects:
                 exec:
                   command:
                     - /bin/sh
-                    - '-i'
-                    - '-c'
+                    - "-i"
+                    - "-c"
                     - >-
                       psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d
                       $POSTGRESQL_DATABASE -c 'SELECT 1'
@@ -282,7 +282,7 @@ objects:
               - postgresql
             from:
               kind: ImageStreamTag
-              name: 'postgresql:9.5'
+              name: "postgresql:9.5"
               namespace: openshift
           type: ImageChange
         - type: ConfigChange
@@ -298,7 +298,7 @@ objects:
       storageClassName: ${POSTGRESQL_PERSISTENT_VOLUME_CLASS}
       resources:
         requests:
-          storage: '${POSTGRESQL_VOLUME_CAPACITY}'
+          storage: "${POSTGRESQL_VOLUME_CAPACITY}"
   - apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
@@ -311,24 +311,24 @@ objects:
       storageClassName: ${SONAR_PERSISTENT_VOLUME_CLASS}
       resources:
         requests:
-          storage: '${SONAR_VOLUME_CAPACITY}'
+          storage: "${SONAR_VOLUME_CAPACITY}"
 parameters:
   - displayName: SonarQube version
     name: SONARQUBE_VERSION
     required: true
-    value: '7.9.1'
+    value: "7.9.1"
   - description: Password for SonarQube Server PostgreSQL backend
     displayName: SonarQube's PostgreSQL Password
-    from: '[a-zA-Z0-9]{16}'
+    from: "[a-zA-Z0-9]{16}"
     generate: expression
     name: POSTGRESQL_PASSWORD
     required: true
   - description: Password for SonarQube Admin
     displayName: SonarQube's Admin Password
-    from: '[a-zA-Z0-9]{8}'
+    from: "[a-zA-Z0-9]{8}"
     generate: expression
     name: SONARQUBE_ADMIN_PASSWORD
-    required: true  
+    required: true
   - description: Volume space available for PostgreSQL
     displayName: PostgreSQL Volume Capacity
     name: POSTGRESQL_VOLUME_CAPACITY
@@ -341,12 +341,11 @@ parameters:
     value: 5Gi
   - name: SONAR_PERSISTENT_VOLUME_CLASS
     displayName: Persistent Volume Class name
-    description: The class of the volume; gluster-file, gluster-block, gluster-file-db
+    description: The class of the volume; netapp-file-standard
     required: false
-    value: gluster-file
+    value: netapp-file-standard
   - name: POSTGRESQL_PERSISTENT_VOLUME_CLASS
     displayName: Persistent Volume Class name
-    description: The class of the volume; gluster-file, gluster-block, gluster-file-db
+    description: The class of the volume; netapp-file-standard
     required: false
-    value: gluster-file-db
-   
+    value: netapp-file-standard


### PR DESCRIPTION
As a follow up of the discussions about gluster/netapps and my lack of success trying to use gluster for a new install, I change the template to use the new storage class.
I was successful in deploying this. 