### PR TITLE
Update the sonarqube-postgresql-template

### DIFF
--- a/sonarqube-postgresql-template.yaml
+++ b/sonarqube-postgresql-template.yaml
@@ -138,6 +138,24 @@ objects:
       password: ${POSTGRESQL_PASSWORD}
 
   - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      labels:
+        app: sonarqube
+        role: ${SONARQUBE_ROLE}
+      name: sonarqube
+    spec:
+      tags:
+        - annotations:
+            description: The SonarQube Docker image
+            tags: sonarqube
+          from:
+            kind: DockerImage
+            name: "${SONARQUBE_SOURCE_IMAGE_NAME}:${SONARQUBE_VERSION}"
+          importPolicy: {}
+          name: "${SONARQUBE_VERSION}"
+
+  - apiVersion: v1
     kind: DeploymentConfig
     metadata:
       labels:

--- a/sonarqube-postgresql-template.yaml
+++ b/sonarqube-postgresql-template.yaml
@@ -177,7 +177,7 @@ objects:
                       key: password
                       name: postgresql-sonar-password
                 - name: SONAR_JDBC_URL
-                  value: "jdbc:postgresql://postgresql-sonarqube/sonar"
+                  value: "jdbc:postgresql://postgresql-sonarqube:5432/sonar"
                 - name: SONAR_JDBC_USERNAME
                   value: sonar
                 - name: SONAR_FORCEAUTHENTICATION

--- a/sonarqube-postgresql-template.yaml
+++ b/sonarqube-postgresql-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 message: "Login to SonarQube with the default admin user: admin/admin"
 metadata:
@@ -138,24 +138,6 @@ objects:
       password: ${POSTGRESQL_PASSWORD}
 
   - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: sonarqube
-        role: ${SONARQUBE_ROLE}
-      name: sonarqube
-    spec:
-      tags:
-        - annotations:
-            description: The SonarQube Docker image
-            tags: sonarqube
-          from:
-            kind: DockerImage
-            name: "${SONARQUBE_SOURCE_IMAGE_NAME}:${SONARQUBE_VERSION}"
-          importPolicy: {}
-          name: "${SONARQUBE_VERSION}"
-
-  - apiVersion: v1
     kind: DeploymentConfig
     metadata:
       labels:
@@ -189,14 +171,14 @@ objects:
         spec:
           containers:
             - env:
-                - name: SONARQUBE_JDBC_PASSWORD
+                - name: SONAR_JDBC_PASSWORD
                   valueFrom:
                     secretKeyRef:
                       key: password
                       name: postgresql-sonar-password
-                - name: SONARQUBE_JDBC_URL
+                - name: SONAR_JDBC_URL
                   value: "jdbc:postgresql://postgresql-sonarqube/sonar"
-                - name: SONARQUBE_JDBC_USERNAME
+                - name: SONAR_JDBC_USERNAME
                   value: sonar
                 - name: SONAR_FORCEAUTHENTICATION
                   value: "true"


### PR DESCRIPTION
I was trying to deploy the yaml template into our tools namespace, but ran into a few issues:
1. OpenShift wanted the API version to be updated to: _template.openshift.io/v1_
2. The ImageStream section of this file is not required when you do the oc new-build command before doing the oc-new app command (as per the instructions)
3. Sonarqube was using it's H2 DB instead of postgres, which was because the environment variables started with SONARQUBE instead of SONAR (they had to match what was in sonar.properties file)
4. Needed to add the port to the Postgres URL